### PR TITLE
[DEV-32] refactor: "필터, 드롭다운" 모든할일목록에 병합

### DIFF
--- a/src/assets/note.svg
+++ b/src/assets/note.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="#F8FAFC"/>
+<rect x="7.5" y="6.90002" width="9" height="10.3846" rx="1.38462" fill="#60A5FA"/>
+<path d="M9.5769 10.0154H14.4231" stroke="white" stroke-width="0.969231" stroke-linecap="round"/>
+<path d="M9.57666 12.0924H14.4228" stroke="white" stroke-width="0.969231" stroke-linecap="round"/>
+<path d="M9.57666 14.1694H14.4228" stroke="white" stroke-width="0.969231" stroke-linecap="round"/>
+</svg>

--- a/src/components/container-recently-todo.tsx
+++ b/src/components/container-recently-todo.tsx
@@ -38,6 +38,7 @@ const mockFetchTodos = async () => {
         hasGoal: Math.random() > 0.5 ? getRandomGoal() : null,
         hasLink: Math.random() > 0.5,
         hasFile: Math.random() > 0.5,
+        hasNote: Math.random() > 0.5,
         createdAt: Date.now() - Math.floor(Math.random() * 10000000),
       }));
       resolve({ todos });

--- a/src/types/container-recently-todo.ts
+++ b/src/types/container-recently-todo.ts
@@ -5,5 +5,34 @@ export interface Todo {
   hasGoal: string | null;
   hasLink: boolean;
   hasFile: boolean;
+  hasNote: boolean;
   createdAt: number;
+}
+export interface TodosResponse {
+  todos: Todo[];
+  nextCursor?: string;
+}
+export interface ListTodoProps {
+  fetchTodos?: (
+    pageParam?: number,
+  ) => Promise<{ todos: Todo[]; nextPage?: number }>;
+}
+export interface BaseTodoProps {
+  index: number;
+  todo: Todo;
+}
+export interface TodoTitleAndCheckBoxProps extends BaseTodoProps {
+  toggleStatus: (id: string) => void;
+}
+export interface TodoEditAndDeleteAndIconsProps extends BaseTodoProps {
+  activeKebab: number | null;
+  handleKebabClick: (index: number) => void;
+}
+export interface NoteProps {
+  todo: Todo;
+}
+export interface DropdownItem {
+  id: string;
+  label: string;
+  onClick: () => void;
 }


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->

## 📑 작업 개요

- 필터 컴포넌트를 가져와 적용했습니다.
- 드롭다운 컴포넌트를 가져와 적용했습니다.

<!-- 이 작업을 진행한 이유 -->

## ✨ 작업 이유

- 사용자가 필터를 이용하여 완료한 일과 해야 할 일을 잘 볼 수 있게 하기 위해서 입니다.
- 사용자가 케밥을 클릭하면 해당 할 일의 수정, 삭제 노트보기 드롭다운이 나온다.

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->

## 📌 작업 내용

- 필터를 가져와 병합
- 드롭다운 가져와 병합

<!-- 실행 화면 캡처 또는 영상 업로드 -->

## 🖥️ 실행 화면

<!-- (선택) 리뷰어에게 전하고 싶은 말 -->

## 🤝🏻 해당 부분을 중점적으로 리뷰해주세요!
- git pull error때문에 다시 올렸습니다.

<!-- 관련 이슈 번호 체크 -->

## 🎟️ 관련 이슈

close:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 투두 항목에 노트 관련 표시 기능이 추가되어, 필요한 경우 노트 아이콘과 드롭다운 메뉴 옵션을 확인할 수 있습니다.
	- 필터링 옵션이 강화되어 투두 관리가 더욱 직관적으로 개선되었습니다.
  
- **리팩터링**
	- 투두 항목 표시 및 관리 로직이 통합·단순화되어 사용자 경험이 한층 개선되었습니다.
	- 데이터 구조가 재구성되어 안정성과 확장성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->