### PR TITLE
[DEV-41] 목표 삭제 기능 구현

### DIFF
--- a/src/app/api/v1/goals/[goalId]/route.ts
+++ b/src/app/api/v1/goals/[goalId]/route.ts
@@ -1,0 +1,20 @@
+export const DELETE = async (
+  request: Request,
+  { params }: { params: { goalId: string } },
+) => {
+  if (params.goalId === "10") {
+    return new Response(
+      JSON.stringify({
+        code: "NOT_ALLOW_REMOVE_GOAL",
+        message: "삭제 권한이 없습니다.",
+      }),
+      {
+        status: 403,
+      },
+    );
+  }
+
+  return new Response(null, {
+    status: 204,
+  });
+};

--- a/src/components/@common/dropdown.tsx
+++ b/src/components/@common/dropdown.tsx
@@ -86,7 +86,10 @@ export default function Dropdown({ items }: DropdownProps) {
               <DropdownItem
                 key={`kebab-dropdown-${label}`}
                 label={label}
-                onClick={onClick}
+                onClick={(e) => {
+                  closeDropdown();
+                  onClick(e);
+                }}
                 isFocus={focusIndex === i}
               />
             ))}

--- a/src/components/goal-detail/goal-summary-dropdown.tsx
+++ b/src/components/goal-detail/goal-summary-dropdown.tsx
@@ -1,8 +1,23 @@
 "use client";
 
-import Dropdown from "../@common/dropdown";
+import { useState } from "react";
 
-export default function GoalSummaryDropdown() {
+import { useDeleteGoal } from "@/hooks/use-delete-goal";
+
+import Dropdown from "../@common/dropdown";
+import Popup from "../@common/portal/popup";
+
+interface GoalSummaryDropdownProps {
+  goalId: string;
+}
+
+export default function GoalSummaryDropdown({
+  goalId,
+}: GoalSummaryDropdownProps) {
+  const [popupOpen, setPopupOpen] = useState<boolean>(false);
+
+  const { mutate: deleteGoal } = useDeleteGoal();
+
   const dropdownItems = [
     {
       label: "수정하기",
@@ -10,9 +25,40 @@ export default function GoalSummaryDropdown() {
     },
     {
       label: "삭제하기",
-      onClick: () => {},
+      onClick: () => {
+        setPopupOpen(true);
+      },
     },
   ];
 
-  return <Dropdown items={dropdownItems} />;
+  const handleGoalDelete = () => {
+    deleteGoal(Number(goalId));
+  };
+
+  return (
+    <>
+      <Dropdown items={dropdownItems} />
+      <Popup.Root open={popupOpen} onOpenChange={setPopupOpen}>
+        <Popup.Trigger className="hidden">삭제하기</Popup.Trigger>
+        <Popup.Content>
+          <div className="flex flex-col items-center justify-center text-base font-medium text-slate-800">
+            <span>목표를 삭제하시겠어요?</span>
+            <span> 삭제된 목표는 복구할 수 없습니다.</span>
+          </div>
+          <Popup.Footer>
+            <Popup.Close variant="outlined" className="text-base font-semibold">
+              취소
+            </Popup.Close>
+            <Popup.Close
+              size="sm"
+              onClick={handleGoalDelete}
+              className="text-base font-semibold"
+            >
+              삭제
+            </Popup.Close>
+          </Popup.Footer>
+        </Popup.Content>
+      </Popup.Root>
+    </>
+  );
 }

--- a/src/components/goal-detail/goal-summary.tsx
+++ b/src/components/goal-detail/goal-summary.tsx
@@ -20,7 +20,7 @@ export default function GoalSummary({ goalId }: GoalSummaryProps) {
             목표 이름 ({goalId})
           </h2>
         </div>
-        <GoalSummaryDropdown />
+        <GoalSummaryDropdown goalId={goalId} />
       </div>
       <div className="mt-24">
         <p className="mb-8 text-xs font-semibold">Progress</p>

--- a/src/hooks/use-delete-goal.ts
+++ b/src/hooks/use-delete-goal.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+import { deleteGoal } from "@/services/goal";
+
+export const useDeleteGoal = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (goalId: number) => deleteGoal(goalId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["goals"],
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: ["dashboard"],
+      });
+
+      router.push("/dashboard");
+    },
+  });
+};

--- a/src/services/goal/index.ts
+++ b/src/services/goal/index.ts
@@ -1,0 +1,9 @@
+import api from "@/lib/axios";
+
+import { ENDPOINT } from "../endpoint";
+
+export const deleteGoal = async (goalId: number) => {
+  const res = await api.delete(ENDPOINT.GOAL.DELETE(goalId));
+
+  return res;
+};


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->

## 📑 작업 개요

- 목표 삭제 기능 추가


<!-- 핵심적인 코드 변경 사항에 대한 설명 -->

## 📌 작업 내용

- 목표 삭제 api 요청 및 mutation 훅 작성
- 목표 삭제 api route 로직 작성 (goalId가 10인 경우 삭제 동작 테스트 가능)
- `Dropdown` 컴포넌트 아이템 클릭 시 드롭다운 자체가 닫히도록 수정
- 목표 삭제 성공 시 대시보드 페이지로 리다이렉트

<!-- 실행 화면 캡처 또는 영상 업로드 -->

## 🖥️ 실행 화면

[삭제 성공]


https://github.com/user-attachments/assets/b5bf88f9-0ddb-4859-b42a-4ece05569f45


삭제 실패 시 동작은 #173 에서 확인 가능합니다.

<!-- (선택) 리뷰어에게 전하고 싶은 말 -->

## 🤝🏻 해당 부분을 중점적으로 리뷰해주세요!

목표 삭제 성공 시, 무효화하는 키 리스트가 적절한지 확인 부탁드려요!

<!-- 관련 이슈 번호 체크 -->

## 🎟️ 관련 이슈

close: #38 
