### PR TITLE
[DEV-107] feat: 계정 정보 출력

### DIFF
--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -67,7 +67,7 @@ export default function LoginForm() {
       setAccessToken(token);
       setUserInfo(response.data.memberInformation);
 
-      router.push("/");
+      router.push("/dashboard");
     } catch (error: unknown) {
       if (error instanceof ApiError) {
         if (

--- a/src/components/tab-side-menu/user-profile.tsx
+++ b/src/components/tab-side-menu/user-profile.tsx
@@ -1,8 +1,8 @@
-import Image from "next/image";
+// import Image from "next/image";
 
 import Profile from "@/assets/icons-big/profile.svg";
 import Button from "@/components/@common/button";
-import { UserInformations } from "@/types/tab-side-menu";
+import { useUserStore } from "@/store/user-store";
 
 import CustomButton from "./custom-button";
 
@@ -12,39 +12,33 @@ const logoutButtonStyle =
 const profileInfoStyle =
   "flex w-full items-end justify-between text-sm md:flex-col md:items-baseline lg:flex-col lg:items-baseline";
 
-export default function UserProfile({
-  isTabOpen,
-  profile,
-}: {
-  isTabOpen: boolean;
-  profile: UserInformations | undefined;
-}) {
+export default function UserProfile({ isTabOpen }: { isTabOpen: boolean }) {
+  const { name, email } = useUserStore();
   if (isTabOpen) return null;
-
   return (
     <>
       <div className="flex w-full gap-12">
         <div className="min-w-40 md:min-w-64 lg:min-w-64">
-          {profile ? (
+          {/* {profile ? (
             <Image
               className="h-full w-full"
               src={profile.profileImage}
-              alt={`${profile.name}의 프로필 이미지`}
+              alt={`${name||"체다치즈"}의 프로필 이미지`}
               width={64}
               height={64}
               layout="responsive"
             />
-          ) : (
-            <Profile />
-          )}
+          ) : ( */}
+          <Profile />
+          {/* )} */}
         </div>
         <div className={profileInfoStyle}>
           <div>
             <p className="text-sm font-semibold text-slate-800">
-              {profile ? profile.name : "체다치즈"}
+              {name || "체다치즈"}
             </p>
             <p className="text-sm font-medium text-slate-600">
-              {profile ? profile.email : "chedacheese@slid.kr"}
+              {email || "chedacheese@slid.kr"}
             </p>
           </div>
           <Button className={logoutButtonStyle}>로그아웃</Button>


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->

## 📑 작업 개요

- auth-store.ts 에서 로그인한 유저의 계정 정보 불러와서 네비게이션에 출력해 넣음
- 이미지는 아직 구현 어려울 것 같아서 (이미지 파일 업로드) 주석 처리 해 놓음

<!-- 실행 화면 캡처 또는 영상 업로드 -->

## 🖥️ 실행 화면

https://github.com/user-attachments/assets/466912e9-6744-4b71-b3c9-763ca9f222a3

<!-- (선택) 리뷰어에게 전하고 싶은 말 -->

## 🤝🏻 해당 부분을 중점적으로 리뷰해주세요!

- 로그인 하다 보니까 로딩이 좀 걸려서 로그인 로딩 할 때에도 로딩 스피넛을 넣으면 좋지 않을 까 싶습니다 @ChaeYubin 
- 로그아웃도 이런 방식으로 구현하면 될 것 같습니다. (맞나요?)

<!-- 관련 이슈 번호 체크 -->

## 🎟️ 관련 이슈

close: #144 
