### PR TITLE
[DEV-125] 로그인/회원가입 API 수정

### DIFF
--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -1,5 +1,6 @@
-import axios, { AxiosResponse } from "axios";
+import { AxiosResponse } from "axios";
 
+import api from "@/lib/axios";
 import { useAuthStore } from "@/store/auth-store";
 import { useUserStore } from "@/store/user-store";
 import { LoginResponse, SignupResponse } from "@/types/auth";
@@ -8,16 +9,12 @@ import { ENDPOINT } from "../endpoint";
 
 import { storeAccessTokenInCookie } from "./route-handler";
 
-const apiNoAuth = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_SERVER_ADDRESS,
-});
-
 /** 로그인 API */
 export const login = async (
   email: string,
   password: string,
 ): Promise<AxiosResponse<LoginResponse>> => {
-  const res = await apiNoAuth.post<LoginResponse>(ENDPOINT.AUTH.LOGIN, {
+  const res = await api.post<LoginResponse>(ENDPOINT.AUTH.LOGIN, {
     email,
     password,
   });
@@ -39,7 +36,7 @@ export const signup = async (
   email: string,
   password: string,
 ): Promise<AxiosResponse<SignupResponse>> => {
-  const res = await apiNoAuth.post<SignupResponse>(ENDPOINT.AUTH.SIGNUP, {
+  const res = await api.post<SignupResponse>(ENDPOINT.AUTH.SIGNUP, {
     name,
     email,
     password,


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->

## 📑 작업 개요

- 로그인/회원가입 API 수정

<!-- 이 작업을 진행한 이유 -->

## ✨ 작업 이유

- 로그인, 회원가입 API의 경우 accessToken을 헤더에 담아 보내지 않아도 되기 때문에 기존의 axios 인스턴스와 구분해서 사용하고자 새로운 axios 인스턴스를 추가했었습니다. 그러나 에러를 관리하려면 기존의 인스턴스와 인터셉터를 똑같이 구성해야 하기 때문에, 중복 코드가 생기는 것보다는 이전 로직이 더 적합하다고 생각했습니다.

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->

## 📌 작업 내용

- apiNoAuth 인스턴스 삭제 및 기존처럼 api 인스턴스 그대로 사용하도록 수정

<!-- 관련 이슈 번호 체크 -->

## 🎟️ 관련 이슈

close: #193 
