### PR TITLE
[Dev 133] 쿼리 키 관리 파일 추가

### DIFF
--- a/src/app/(main)/goals/[goalId]/page.tsx
+++ b/src/app/(main)/goals/[goalId]/page.tsx
@@ -4,8 +4,10 @@ import GoalSummary from "@/components/goal-detail/goal-summary";
 import RouteButtonToNotes from "@/components/goal-detail/route-button-to-notes";
 import TodoList from "@/components/goal-detail/todo-list";
 import getQueryClient from "@/lib/get-query-client";
-import { getProgressByGoalIdOptions } from "@/services/dashboard/query";
-import { getGoalOptions } from "@/services/goal/query";
+import {
+  getGoalOptions,
+  getProgressByGoalIdOptions,
+} from "@/services/goal/query";
 import { getInfiniteTodosByGoalIdOptions } from "@/services/todo/query";
 
 export default async function GoalDetailPage({

--- a/src/components/@common/todo-modal/goal-dropdown.tsx
+++ b/src/components/@common/todo-modal/goal-dropdown.tsx
@@ -19,7 +19,7 @@ interface GoalDropdownProps {
 
 export default function GoalDropdown({ goalId }: GoalDropdownProps) {
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
-    getInfiniteGoalsOptions({ size: 20, moreKeys: ["goal-dropdown"] }),
+    getInfiniteGoalsOptions({ size: 20 }),
   );
   const { ref: scrollRef, refTrigger } = useInfiniteScroll({
     hasNextPage,

--- a/src/components/dashboard/todos-by-goal/goal-item-progress-bar.tsx
+++ b/src/components/dashboard/todos-by-goal/goal-item-progress-bar.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import ProgressBar from "@/components/@common/progress-bar";
-import { getProgressByGoalIdOptions } from "@/services/dashboard/query";
+import { getProgressByGoalIdOptions } from "@/services/goal/query";
 
 interface GoalItemProgressBarProps {
   goalId: number;

--- a/src/components/goal-detail/goal-summary.tsx
+++ b/src/components/goal-detail/goal-summary.tsx
@@ -5,8 +5,10 @@ import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import FlagGoalIcon from "@/assets/icons-big/flag_goal.svg";
-import { getProgressByGoalIdOptions } from "@/services/dashboard/query";
-import { getGoalOptions } from "@/services/goal/query";
+import {
+  getGoalOptions,
+  getProgressByGoalIdOptions,
+} from "@/services/goal/query";
 
 import ProgressBar from "../@common/progress-bar";
 

--- a/src/hooks/query/use-goal.ts
+++ b/src/hooks/query/use-goal.ts
@@ -4,6 +4,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
 import { createGoal, deleteGoal, updateGoal } from "@/services/goal";
+import { invalidateGoalRelatedQueries } from "@/services/invalidate";
+import { goalKeys } from "@/services/query-key";
 import { GoalResponse } from "@/types/dashboard";
 
 export const useDeleteGoal = () => {
@@ -13,13 +15,7 @@ export const useDeleteGoal = () => {
   return useMutation({
     mutationFn: (goalId: number) => deleteGoal(goalId),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["goals"],
-      });
-
-      queryClient.invalidateQueries({
-        queryKey: ["dashboard", "todos", "recent"],
-      });
+      invalidateGoalRelatedQueries(queryClient);
 
       router.push("/dashboard");
     },
@@ -34,7 +30,7 @@ export const useUpdateGoal = () => {
       updateGoal(goalId, title),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
-        queryKey: ["goal", { goalId: variables.goalId }],
+        queryKey: goalKeys.detail(variables.goalId),
       });
     },
   });
@@ -46,9 +42,7 @@ export const useCreateGoal = () => {
   return useMutation<GoalResponse, Error, { title: string }>({
     mutationFn: createGoal,
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["goals"],
-      });
+      invalidateGoalRelatedQueries(queryClient);
     },
   });
 };

--- a/src/hooks/query/use-goal.ts
+++ b/src/hooks/query/use-goal.ts
@@ -28,9 +28,9 @@ export const useUpdateGoal = () => {
   return useMutation({
     mutationFn: ({ goalId, title }: { goalId: number; title: string }) =>
       updateGoal(goalId, title),
-    onSuccess: (_, variables) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: goalKeys.detail(variables.goalId),
+        queryKey: goalKeys.all,
       });
     },
   });

--- a/src/hooks/query/use-todo.ts
+++ b/src/hooks/query/use-todo.ts
@@ -1,9 +1,6 @@
-import {
-  QueryClient,
-  useMutation,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
+import { invalidateTodoRelatedQueries } from "@/services/invalidate";
 import {
   createTodo,
   deleteTodo,
@@ -11,22 +8,13 @@ import {
   updateTodo,
 } from "@/services/todo";
 
-const invalidateTodo = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: ["todos"],
-  });
-  queryClient.invalidateQueries({
-    queryKey: ["dashboard", "todos", "recent"],
-  });
-};
-
 export const useCreateTodo = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (newTodo: TodoParams) => createTodo(newTodo),
     onSuccess: () => {
-      invalidateTodo(queryClient);
+      invalidateTodoRelatedQueries(queryClient);
     },
   });
 };
@@ -43,7 +31,7 @@ export const useUpdateTodo = () => {
       newTodo: TodoParams;
     }) => updateTodo(todoId, newTodo),
     onSuccess: () => {
-      invalidateTodo(queryClient);
+      invalidateTodoRelatedQueries(queryClient);
     },
   });
 };
@@ -54,7 +42,7 @@ export const useDeleteTodo = () => {
   return useMutation({
     mutationFn: (todoId: number) => deleteTodo(todoId),
     onSuccess: () => {
-      invalidateTodo(queryClient);
+      invalidateTodoRelatedQueries(queryClient);
     },
   });
 };

--- a/src/services/dashboard/index.ts
+++ b/src/services/dashboard/index.ts
@@ -46,15 +46,3 @@ export const getInfiniteTodosByGoalId = async ({
   });
   return data;
 };
-
-export const getProgressByGoalId = async (goalId: number) => {
-  const { data } = await api.get<{ progress: number }>(
-    ENDPOINT.GOAL.GET_PROGRESS,
-    {
-      params: {
-        goalId,
-      },
-    },
-  );
-  return data;
-};

--- a/src/services/dashboard/query.ts
+++ b/src/services/dashboard/query.ts
@@ -3,26 +3,22 @@ import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import { TodosByGoalParams } from "@/types/dashboard";
 import { GoalListParams } from "@/types/goal";
 
-import {
-  getDashboard,
-  getInfiniteGoals,
-  getInfiniteTodosByGoalId,
-  getProgressByGoalId,
-} from ".";
+import { dashboardKeys, goalKeys, todoKeys } from "../query-key";
+
+import { getDashboard, getInfiniteGoals, getInfiniteTodosByGoalId } from ".";
 
 export const getDashboardOptions = () =>
   queryOptions({
-    queryKey: ["dashboard", "todos", "recent"],
+    queryKey: dashboardKeys.recent(),
     queryFn: () => getDashboard(),
   });
 
 export const getInfiniteGoalsOptions = ({
   size = 3,
-  moreKeys = [],
   sortOrder = "newest",
 }: GoalListParams) => {
   return infiniteQueryOptions({
-    queryKey: ["goals", ...moreKeys],
+    queryKey: goalKeys.list(size),
     queryFn: ({ pageParam }) =>
       getInfiniteGoals({ size, sortOrder, cursor: pageParam }),
     getNextPageParam: (lastPage) =>
@@ -43,7 +39,7 @@ export const getDashboardInfiniteTodosByGoalIdOptions = ({
   done,
 }: TodosByGoalParams) => {
   return infiniteQueryOptions({
-    queryKey: ["todos", goalId, done],
+    queryKey: todoKeys.list({ size, goalId, done }),
     queryFn: ({ pageParam }) => {
       return getInfiniteTodosByGoalId({
         goalId,
@@ -65,9 +61,3 @@ export const getDashboardInfiniteTodosByGoalIdOptions = ({
     }),
   });
 };
-
-export const getProgressByGoalIdOptions = (goalId: number) =>
-  queryOptions({
-    queryKey: ["progress", goalId],
-    queryFn: () => getProgressByGoalId(goalId),
-  });

--- a/src/services/goal/index.ts
+++ b/src/services/goal/index.ts
@@ -27,3 +27,15 @@ export const createGoal = async (newGoal: { title: string }) => {
   const { data } = await api.post<GoalResponse>(ENDPOINT.GOAL.CREATE, newGoal);
   return data;
 };
+
+export const getProgressByGoalId = async (goalId: number) => {
+  const { data } = await api.get<{ progress: number }>(
+    ENDPOINT.GOAL.GET_PROGRESS,
+    {
+      params: {
+        goalId,
+      },
+    },
+  );
+  return data;
+};

--- a/src/services/goal/query.ts
+++ b/src/services/goal/query.ts
@@ -1,9 +1,17 @@
 import { queryOptions } from "@tanstack/react-query";
 
-import { getGoal } from ".";
+import { goalKeys } from "../query-key";
+
+import { getGoal, getProgressByGoalId } from ".";
 
 export const getGoalOptions = (id: number) =>
   queryOptions({
-    queryKey: ["goal", { goalId: id }],
+    queryKey: goalKeys.detail(id),
     queryFn: () => getGoal(id),
+  });
+
+export const getProgressByGoalIdOptions = (id: number) =>
+  queryOptions({
+    queryKey: goalKeys.progress(id),
+    queryFn: () => getProgressByGoalId(id),
   });

--- a/src/services/invalidate.ts
+++ b/src/services/invalidate.ts
@@ -1,0 +1,20 @@
+import { QueryClient } from "@tanstack/react-query";
+
+import { dashboardKeys, goalKeys, todoKeys } from "./query-key";
+
+export const invalidateGoalRelatedQueries = (queryClient: QueryClient) => {
+  queryClient.invalidateQueries({ queryKey: goalKeys.all });
+  queryClient.invalidateQueries({ queryKey: dashboardKeys.progress() });
+};
+
+export const invalidateTodoRelatedQueries = (
+  queryClient: QueryClient,
+  goalId?: number,
+) => {
+  queryClient.invalidateQueries({ queryKey: todoKeys.all });
+  queryClient.invalidateQueries({ queryKey: dashboardKeys.recent });
+
+  if (goalId) {
+    queryClient.invalidateQueries({ queryKey: goalKeys.progress(goalId) });
+  }
+};

--- a/src/services/query-key.ts
+++ b/src/services/query-key.ts
@@ -1,0 +1,27 @@
+import { TodosByGoalParams } from "@/types/todo";
+
+export const goalKeys = {
+  all: ["goals"] as const,
+  list: (size: number) => [...goalKeys.all, "list", { size }] as const,
+  detail: (id: number) => [...goalKeys.all, "detail", { goalId: id }] as const,
+  progress: (id: number) =>
+    [...goalKeys.all, "progress", { goalId: id }] as const,
+};
+
+export const todoKeys = {
+  all: ["todos"] as const,
+  list: ({ size, goalId, done }: TodosByGoalParams) =>
+    [...todoKeys.all, "list", { size, goalId, done }] as const,
+  detail: (id: number) => [...todoKeys.all, "detail", { todoId: id }] as const,
+};
+
+export const dashboardKeys = {
+  all: ["dashboard"] as const,
+  recent: () => [...dashboardKeys.all, "todos", "recent"] as const,
+  progress: () => [...dashboardKeys.all, "progress"] as const,
+};
+
+export const noteKeys = {
+  all: ["notes"] as const,
+  detail: (id: number) => [...noteKeys.all, "detail", { noteId: id }] as const,
+};

--- a/src/services/todo/query.ts
+++ b/src/services/todo/query.ts
@@ -3,14 +3,15 @@ import { infiniteQueryOptions } from "@tanstack/react-query";
 import { TodosByGoalParams } from "@/types/dashboard";
 
 import { getInfiniteTodosByGoalId } from "../dashboard";
+import { todoKeys } from "../query-key";
 
 export const getInfiniteTodosByGoalIdOptions = ({
   goalId,
-  size = 30,
+  size = 40,
   done,
 }: TodosByGoalParams) => {
   return infiniteQueryOptions({
-    queryKey: ["todos", { goalId, isDone: done }],
+    queryKey: todoKeys.list({ size, goalId, done }),
     queryFn: ({ pageParam }) => {
       return getInfiniteTodosByGoalId({
         goalId,

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -1,7 +1,7 @@
 import { GoalSimpleResponse } from "./goal";
 
 export interface TodosByGoalParams {
-  goalId: number;
+  goalId?: number;
   cursor?: number;
   size?: number;
   done?: boolean;


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->
## 📑 작업 개요
- 쿼리 키 관리를 위한 query-key.ts, invalidate.ts 추가

<!-- 이 작업을 진행한 이유 -->
## ✨ 작업 이유
- 도메인이 겹치는 영역을 각자 작업하면서 쿼리 키가 어떻게 쓰였는지 직접 찾아봐야 하는 문제가 있었습니다. 쿼리 키에 어떤 값을 넣어야 하는지 고민하는 시간을 줄여 생산성을 높이고, 한 곳에서 관리하여 쿼리 키가 잘못 입력되는 상황을 방지하고자 객체로 쿼리 키를 관리하는 방식으로 수정했습니다.

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->
## 📌 작업 내용
- `query-key.ts`: 도메인 별로 필요한 쿼리 키 정의
- `invalidate.ts`: 연관된 쿼리를 안전하게 무효화하기 위해 미리 정의한 유틸 함수
- 기존에 존재하던 요청의 쿼리 키 일괄적으로 수정

<!-- 관련 이슈 번호 체크 -->
## 🎟️ 관련 이슈
close: #217 