### PR TITLE
[Dev 135] 유저 정보 저장 방식 수정

### DIFF
--- a/src/components/@common/skeleton.tsx
+++ b/src/components/@common/skeleton.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/cn";
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export default function Skeleton({ className }: SkeletonProps) {
+  return (
+    <div role="status" className="animate-pulse">
+      <div
+        className={cn(
+          "h-2.5 w-48 rounded-full bg-gray-200 dark:bg-gray-700",
+          className,
+        )}
+      />
+      <span className="sr-only">Loading...</span>
+    </div>
+  );
+}

--- a/src/components/tab-side-menu/user-profile.tsx
+++ b/src/components/tab-side-menu/user-profile.tsx
@@ -17,7 +17,7 @@ const profileInfoStyle =
   "flex w-full items-end justify-between text-sm md:flex-col md:items-baseline lg:flex-col lg:items-baseline";
 
 export default function UserProfile({ isTabOpen }: { isTabOpen: boolean }) {
-  const { name, email } = useUserStore();
+  const { userInformation } = useUserStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   if (isTabOpen) return null;
@@ -25,26 +25,15 @@ export default function UserProfile({ isTabOpen }: { isTabOpen: boolean }) {
     <>
       <div className="flex w-full gap-12">
         <div className="min-w-40 md:min-w-64 lg:min-w-64">
-          {/* {profile ? (
-            <Image
-              className="h-full w-full"
-              src={profile.profileImage}
-              alt={`${name||"체다치즈"}의 프로필 이미지`}
-              width={64}
-              height={64}
-              layout="responsive"
-            />
-          ) : ( */}
           <Profile />
-          {/* )} */}
         </div>
         <div className={profileInfoStyle}>
           <div>
             <p className="text-sm font-semibold text-slate-800">
-              {name || "체다치즈"}
+              {userInformation?.name || "체다치즈"}
             </p>
             <p className="text-sm font-medium text-slate-600">
-              {email || "chedacheese@slid.kr"}
+              {userInformation?.email || "chedacheese@slid.kr"}
             </p>
           </div>
           <Button className={logoutButtonStyle}>로그아웃</Button>

--- a/src/components/tab-side-menu/user-profile.tsx
+++ b/src/components/tab-side-menu/user-profile.tsx
@@ -1,11 +1,10 @@
-// import Image from "next/image";
-
 import { useState } from "react";
 
 import Profile from "@/assets/icons-big/profile.svg";
 import Button from "@/components/@common/button";
 import { useUserStore } from "@/store/user-store";
 
+import Skeleton from "../@common/skeleton";
 import TodoModal from "../@common/todo-modal/todo-modal";
 
 import CustomButton from "./custom-button";
@@ -29,12 +28,21 @@ export default function UserProfile({ isTabOpen }: { isTabOpen: boolean }) {
         </div>
         <div className={profileInfoStyle}>
           <div>
-            <p className="text-sm font-semibold text-slate-800">
-              {userInformation?.name || "체다치즈"}
-            </p>
-            <p className="text-sm font-medium text-slate-600">
-              {userInformation?.email || "chedacheese@slid.kr"}
-            </p>
+            {userInformation ? (
+              <>
+                <p className="text-sm font-semibold text-slate-800">
+                  {userInformation.name || ""}
+                </p>
+                <p className="text-sm font-medium text-slate-600">
+                  {userInformation.email || ""}
+                </p>
+              </>
+            ) : (
+              <div className="flex flex-col gap-y-10 pt-4">
+                <Skeleton className="h-11 w-50" />
+                <Skeleton className="h-11 w-132" />
+              </div>
+            )}
           </div>
           <Button className={logoutButtonStyle}>로그아웃</Button>
         </div>

--- a/src/store/user-store.ts
+++ b/src/store/user-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 import { MemberInformation } from "@/types/auth";
 
@@ -11,14 +12,21 @@ interface UserState {
   };
 }
 
-export const useUserStore = create<UserState>()((set) => ({
-  userInformation: null,
+export const useUserStore = create<UserState>()(
+  persist(
+    (set) => ({
+      userInformation: null,
 
-  actions: {
-    setUserInfo: ({ id, email, name }: MemberInformation) =>
-      set({ userInformation: { id, email, name } }),
-    removeUserInfo: () => set({ userInformation: null }),
-  },
-}));
+      actions: {
+        setUserInfo: ({ id, email, name }: MemberInformation) =>
+          set({ userInformation: { id, email, name } }),
+        removeUserInfo: () => set({ userInformation: null }),
+      },
+    }),
+    {
+      name: "user-information",
+    },
+  ),
+);
 
 export const useUserActions = () => useUserStore((state) => state.actions);

--- a/src/store/user-store.ts
+++ b/src/store/user-store.ts
@@ -3,9 +3,7 @@ import { create } from "zustand";
 import { MemberInformation } from "@/types/auth";
 
 interface UserState {
-  id: number;
-  email: string;
-  name: string;
+  userInformation: MemberInformation | null;
 
   actions: {
     setUserInfo: (userInfo: MemberInformation) => void;
@@ -13,19 +11,13 @@ interface UserState {
   };
 }
 
-const initialState = {
-  id: 0,
-  email: "",
-  name: "",
-};
-
 export const useUserStore = create<UserState>()((set) => ({
-  ...initialState,
+  userInformation: null,
 
   actions: {
     setUserInfo: ({ id, email, name }: MemberInformation) =>
-      set({ id, email, name }),
-    removeUserInfo: () => set(initialState),
+      set({ userInformation: { id, email, name } }),
+    removeUserInfo: () => set({ userInformation: null }),
   },
 }));
 


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->
## 📑 작업 개요
- 유저 정보 저장 방식 수정

<!-- 이 작업을 진행한 이유 -->
## ✨ 작업 이유
- 로그인 시 응답으로 받아오는 유저 정보를 zustand store에 저장하여 사용 중이었으나, 새로고침 시 store가 초기화되기 때문에 유저 정보가 올바른 값으로 보이지 않는 문제 발생

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->
## 📌 작업 내용
- zustand persist 미들웨어 도입하여 유저 정보를 로컬 스토리지에 저장
- `Skeleton` 컴포넌트 추가
  - 로컬 스토리지에 있는 값을 가져오는 데 걸리는 시간 때문에 프로필 정보가 비어있는 채로 보이는 것을 방지하기 위해 추가
- 유저 정보의 초기값을 명시적으로 `null`로 설정

<!-- (선택) 리뷰어에게 전하고 싶은 말 -->
## 🤝🏻 해당 부분을 중점적으로 리뷰해주세요!
추후 로컬 스토리지에 저장하는 대신, 로그인하여 유저 정보를 받아올 때 이 값을 쿠키에 저장하여 서버에서 미리 렌더링해 보여주는 방식으로 수정도 가능할 것 같습니다. 다만 현재 다른 작업들의 우선순위가 더 높아 임시로 해당 방법으로 처리해둔 점 참고 부탁드립니다.

<!-- (선택) 실행 화면 캡처 또는 영상 업로드 -->
## 🖥️ 실행 화면

https://github.com/user-attachments/assets/91b1c165-88b3-4407-b88b-d1dffb6e6f55


<!-- 관련 이슈 번호 체크 -->
## 🎟️ 관련 이슈
close: #225 #144 