### PR TITLE
[Dev 141] persist 도입 이후 로그인 성공 시 대시보드로 이동하지 않는 문제 해결

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -57,7 +57,7 @@ api.interceptors.response.use(
 
         throw new Error("토큰 갱신에 실패했습니다.");
       } catch (reissueError) {
-        const { removeAccessToken } = useAuthStore.getState().actions;
+        const { removeAccessToken } = useAuthStore.getState();
         removeAccessToken();
 
         return Promise.reject(new ApiError("로그인이 필요합니다."));

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -23,7 +23,7 @@ export const login = async (
   const { memberInformation } = res.data;
 
   useAuthStore.getState().actions.setAccessToken(accessToken);
-  useUserStore.getState().actions.setUserInfo(memberInformation);
+  useUserStore.getState().setUserInfo(memberInformation);
 
   await storeAccessTokenInCookie(accessToken);
 

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -22,7 +22,7 @@ export const login = async (
   const { accessToken } = res.data.credentials;
   const { memberInformation } = res.data;
 
-  useAuthStore.getState().actions.setAccessToken(accessToken);
+  useAuthStore.getState().setAccessToken(accessToken);
   useUserStore.getState().setUserInfo(memberInformation);
 
   await storeAccessTokenInCookie(accessToken);

--- a/src/store/auth-store.ts
+++ b/src/store/auth-store.ts
@@ -3,10 +3,8 @@ import { create } from "zustand";
 interface AuthState {
   accessToken: string | null;
 
-  actions: {
-    setAccessToken: (token: string) => void;
-    removeAccessToken: () => void;
-  };
+  setAccessToken: (token: string) => void;
+  removeAccessToken: () => void;
 }
 
 const initialState = {
@@ -16,10 +14,6 @@ const initialState = {
 export const useAuthStore = create<AuthState>()((set) => ({
   ...initialState,
 
-  actions: {
-    setAccessToken: (token: string) => set({ accessToken: token }),
-    removeAccessToken: () => set(initialState),
-  },
+  setAccessToken: (token: string) => set({ accessToken: token }),
+  removeAccessToken: () => set(initialState),
 }));
-
-export const useAuthActions = () => useAuthStore((state) => state.actions);

--- a/src/store/user-store.ts
+++ b/src/store/user-store.ts
@@ -6,10 +6,8 @@ import { MemberInformation } from "@/types/auth";
 interface UserState {
   userInformation: MemberInformation | null;
 
-  actions: {
-    setUserInfo: (userInfo: MemberInformation) => void;
-    removeUserInfo: () => void;
-  };
+  setUserInfo: (userInfo: MemberInformation) => void;
+  removeUserInfo: () => void;
 }
 
 export const useUserStore = create<UserState>()(
@@ -17,16 +15,12 @@ export const useUserStore = create<UserState>()(
     (set) => ({
       userInformation: null,
 
-      actions: {
-        setUserInfo: ({ id, email, name }: MemberInformation) =>
-          set({ userInformation: { id, email, name } }),
-        removeUserInfo: () => set({ userInformation: null }),
-      },
+      setUserInfo: ({ id, email, name }: MemberInformation) =>
+        set({ userInformation: { id, email, name } }),
+      removeUserInfo: () => set({ userInformation: null }),
     }),
     {
       name: "user-information",
     },
   ),
 );
-
-export const useUserActions = () => useUserStore((state) => state.actions);


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->
## 📑 작업 개요
- persist 도입 이후 로그인 성공 시 대시보드로 이동하지 않는 문제 해결

<!-- 이 작업을 진행한 이유 -->
## ✨ 작업 이유
- #228 PR 머지 이후 로그인 성공 시 대시보드로 이동하지 않는 문제 발생

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->
## 📌 작업 내용
- store 내부에서 actions라는 객체로 관리되던 상태 변경 메서드들을 객체 외부로 이동

<!-- (선택) 리뷰어에게 전하고 싶은 말 -->
## 🤝🏻 해당 부분을 중점적으로 리뷰해주세요!
`persist` 미들웨어 사용 시 `actions` 내부에 있는 상태 변경 메서드들을 인식하지 못해(`undefined`) 발생한 문제였습니다.
이를 해결하기 위해 useUserStore에서 actions를 삭제하였고, 일관성을 위해 useAuthStore의 actions도 삭제했습니다.

<!-- 관련 이슈 번호 체크 -->
## 🎟️ 관련 이슈
close: #233 