### PR TITLE
[Dev 149] 요청 성공 응답 시 토스트 메시지 기능 추가

### DIFF
--- a/src/components/@common/todo-modal/todo-modal-form.tsx
+++ b/src/components/@common/todo-modal/todo-modal-form.tsx
@@ -36,7 +36,7 @@ export default function TodoModalForm({
     selectedGoalId,
   } = formContextValue;
   const { mutate: createMutate } = useCreateTodo();
-  const { mutate: updateMutate } = useUpdateTodo();
+  const { mutate: updateMutate } = useUpdateTodo({ updateAll: true });
 
   const isDone = watch("isDone");
 

--- a/src/components/tab-side-menu/user-profile.tsx
+++ b/src/components/tab-side-menu/user-profile.tsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
 
 import { cva } from "class-variance-authority";
+import { useRouter } from "next/navigation";
 
 import Profile from "@/assets/icons-big/profile.svg";
 import { logout } from "@/services/auth";
 import { useUserStore } from "@/store/user-store";
+import { successToast } from "@/utils/custom-toast";
 
 import Skeleton from "../@common/skeleton";
 import TodoModal from "../@common/todo-modal/todo-modal";
@@ -33,12 +35,16 @@ const profileInfoStyle =
   "flex w-full items-end justify-between text-sm md:flex-col md:items-baseline lg:flex-col lg:items-baseline";
 
 export default function UserProfile({ isTabOpen }: { isTabOpen: boolean }) {
+  const router = useRouter();
+
   const { userInformation } = useUserStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const logoutHandler = async () => {
     logout();
-    window.location.href = "/login";
+
+    successToast("logout", "로그아웃 되었습니다.");
+    router.push("/login");
   };
 
   return (

--- a/src/components/todo/todo-title-checkbox.tsx
+++ b/src/components/todo/todo-title-checkbox.tsx
@@ -14,7 +14,7 @@ export default function TodoTitleAndCheckBox({
   todo,
 }: TodoTitleAndCheckBoxProps) {
   const { isDone } = todo;
-  const { mutate: toggleStatus, isPending } = useUpdateTodo();
+  const { mutate: toggleStatus, isPending } = useUpdateTodo({});
 
   return (
     <div

--- a/src/hooks/query/use-goal.ts
+++ b/src/hooks/query/use-goal.ts
@@ -7,6 +7,7 @@ import { createGoal, deleteGoal, updateGoal } from "@/services/goal";
 import { invalidateGoalRelatedQueries } from "@/services/invalidate";
 import { goalKeys } from "@/services/query-key";
 import { GoalResponse } from "@/types/dashboard";
+import { successToast } from "@/utils/custom-toast";
 
 export const useDeleteGoal = () => {
   const queryClient = useQueryClient();
@@ -16,6 +17,7 @@ export const useDeleteGoal = () => {
     mutationFn: (goalId: number) => deleteGoal(goalId),
     onSuccess: () => {
       invalidateGoalRelatedQueries(queryClient);
+      successToast("delete-goal", "목표가 삭제되었습니다.");
 
       router.push("/dashboard");
     },
@@ -32,6 +34,8 @@ export const useUpdateGoal = () => {
       queryClient.invalidateQueries({
         queryKey: goalKeys.all,
       });
+
+      successToast("update-goal", "목표가 수정되었습니다.");
     },
   });
 };
@@ -43,6 +47,7 @@ export const useCreateGoal = () => {
     mutationFn: createGoal,
     onSuccess: () => {
       invalidateGoalRelatedQueries(queryClient);
+      successToast("create-goal", "목표가 생성되었습니다.");
     },
   });
 };

--- a/src/hooks/query/use-todo.ts
+++ b/src/hooks/query/use-todo.ts
@@ -7,6 +7,7 @@ import {
   TodoParams,
   updateTodo,
 } from "@/services/todo";
+import { successToast } from "@/utils/custom-toast";
 
 export const useCreateTodo = () => {
   const queryClient = useQueryClient();
@@ -15,11 +16,12 @@ export const useCreateTodo = () => {
     mutationFn: (newTodo: TodoParams) => createTodo(newTodo),
     onSuccess: (data) => {
       invalidateTodoRelatedQueries(queryClient, data.goalInformation?.id);
+      successToast("create-todo", "할 일이 생성되었습니다.");
     },
   });
 };
 
-export const useUpdateTodo = () => {
+export const useUpdateTodo = ({ updateAll }: { updateAll?: boolean }) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -32,6 +34,10 @@ export const useUpdateTodo = () => {
     }) => updateTodo(todoId, newTodo),
     onSuccess: (data) => {
       invalidateTodoRelatedQueries(queryClient, data.goalInformation?.id);
+
+      if (updateAll) {
+        successToast("update-todo", "할 일이 수정되었습니다.");
+      }
     },
   });
 };
@@ -43,6 +49,7 @@ export const useDeleteTodo = (goalId?: number) => {
     mutationFn: (todoId: number) => deleteTodo(todoId),
     onSuccess: () => {
       invalidateTodoRelatedQueries(queryClient, goalId);
+      successToast("delete-todo", "할 일이 삭제되었습니다.");
     },
   });
 };

--- a/src/utils/custom-toast.ts
+++ b/src/utils/custom-toast.ts
@@ -1,0 +1,34 @@
+import toast from "react-hot-toast";
+
+export const errorToast = (id: string, message: string) => {
+  toast(message, {
+    id,
+    style: {
+      borderRadius: "28px",
+      background: "black",
+      color: "white",
+      boxShadow: "0px 2px 4px -1px rgba(0, 0, 0, 0.06)",
+      fontSize: "0.875rem",
+      fontStyle: "normal",
+      fontWeight: 600,
+      lineHeight: "1.25rem",
+    },
+  });
+};
+
+export const successToast = (id: string, message: string) => {
+  toast(message, {
+    id,
+    style: {
+      borderRadius: "28px",
+      background: "black",
+      color: "white",
+      boxShadow: "0px 2px 4px -1px rgba(0, 0, 0, 0.06)",
+      fontSize: "0.875rem",
+      fontStyle: "normal",
+      fontWeight: 600,
+      lineHeight: "1.25rem",
+    },
+    duration: 2_000,
+  });
+};

--- a/src/utils/handle-mutation-error.ts
+++ b/src/utils/handle-mutation-error.ts
@@ -1,20 +1,9 @@
-import toast from "react-hot-toast";
-
 import { ApiError } from "@/lib/error";
+
+import { errorToast } from "./custom-toast";
 
 export const handleMutationError = (error: unknown) => {
   if (error instanceof ApiError) {
-    toast(error.message, {
-      style: {
-        borderRadius: "28px",
-        background: "black",
-        color: "white",
-        boxShadow: "0px 2px 4px -1px rgba(0, 0, 0, 0.06)",
-        fontSize: "0.875rem",
-        fontStyle: "normal",
-        fontWeight: 600,
-        lineHeight: "1.25rem",
-      },
-    });
+    errorToast(error.code, error.message);
   }
 };


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->
## 📑 작업 개요
- 요청 성공 응답 시 토스트 메시지 기능 추가

<!-- 이 작업을 진행한 이유 -->
## ✨ 작업 이유
- 사용자가 할일, 목표를 생성/수정/삭제했을 때, 로그아웃 했을 때 완료 상태를 피드백 해주기 위해 추가했습니다.

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->
## 📌 작업 내용
- `utils/custom-toast.ts` 파일 추가 (error, success 용 custom toast 작성)
- 목표/요청 성공 시 토스트 메시지 띄우는 로직 추가

<!-- (선택) 리뷰어에게 전하고 싶은 말 -->
## 🤝🏻 해당 부분을 중점적으로 리뷰해주세요!
- 할일 수정 요청이 1. 할일의 완료 여부가 변경될 때, 2. 할일 전체 내용을 수정할 때 이렇게 두 가지 경우에서 발생하는데, 1번은 사용자에게 피드백이 충분히 제공된다고 생각해(체크박스 체크 유무 변경, 진행률 변경 등) 2번인 경우에만 토스트 메시지를 띄우도록 했습니다. 혹시 관련해서 다른 의견 있으시면 편하게 말씀해주세요.
- 아래 실행 화면에서 로그아웃 후 발생하는 에러는 로컬 환경에서 리프레시 토큰이 쿠키에 저장되지 않기 때문에 발생하는 문제로, 배포된 환경에서는 해당 문제가 발생하지 않으니 신경쓰지 않으셔도 됩니다.


<!-- (선택) 실행 화면 캡처 또는 영상 업로드 -->
## 🖥️ 실행 화면

https://github.com/user-attachments/assets/ed5b5d7e-cec4-4eff-8c38-23ff61bb559f


<!-- 관련 이슈 번호 체크 -->
## 🎟️ 관련 이슈

close: #254 
