### PR TITLE
[DEV 151] 목표 상세 페이지 투두리스트 UI 수정

### DIFF
--- a/src/components/goal-detail/todo-list.tsx
+++ b/src/components/goal-detail/todo-list.tsx
@@ -84,7 +84,7 @@ export default function TodoList({ goalId, done }: TodoListProps) {
           <div className="relative">
             <div
               className={cn(
-                "pointer-events-none absolute left-0 top-0 h-50 w-full bg-gradient-to-b to-transparent transition-opacity duration-300",
+                "pointer-events-none absolute left-0 top-0 z-10 h-50 w-full bg-gradient-to-b to-transparent transition-opacity duration-300",
                 showTopGradient ? "opacity-100" : "opacity-0",
                 done ? "from-slate-200" : "from-white",
               )}

--- a/src/components/goal-detail/todo-list.tsx
+++ b/src/components/goal-detail/todo-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 
@@ -9,7 +9,6 @@ import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 import { cn } from "@/lib/cn";
 import { getInfiniteTodosByGoalIdOptions } from "@/services/todo/query";
 
-import LoadingSpinner from "../@common/loading-spinner";
 import Todo from "../@common/todo";
 import TodoModal from "../@common/todo-modal/todo-modal";
 
@@ -20,10 +19,14 @@ interface TodoListProps {
 
 export default function TodoList({ goalId, done }: TodoListProps) {
   const [showCreateTodoModal, setShowCreateTodoModal] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [showTopGradient, setShowTopGradient] = useState(false);
+  const [showBottomGradient, setShowBottomGradient] = useState(false);
 
   const { data, fetchNextPage, hasNextPage } = useSuspenseInfiniteQuery(
     getInfiniteTodosByGoalIdOptions({
       goalId: Number(goalId),
+      size: 7,
       done,
     }),
   );
@@ -32,6 +35,26 @@ export default function TodoList({ goalId, done }: TodoListProps) {
     hasNextPage,
     fetchNextPage,
   });
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!scrollRef.current) {
+        return;
+      }
+
+      setShowTopGradient(scrollRef.current.scrollTop > 0);
+      setShowBottomGradient(
+        scrollRef.current.scrollHeight - scrollRef.current.scrollTop >
+          scrollRef.current.clientHeight + 5,
+      );
+    };
+
+    const element = scrollRef.current;
+    element?.addEventListener("scroll", handleScroll);
+    handleScroll();
+
+    return () => element?.removeEventListener("scroll", handleScroll);
+  }, [data]);
 
   return (
     <>
@@ -58,24 +81,44 @@ export default function TodoList({ goalId, done }: TodoListProps) {
           )}
         </div>
         {data.todos.length > 0 ? (
-          <div className="mt-16">
-            {data.todos.length > 0 && (
-              <ul className="flex flex-col gap-8">
-                {data.todos.map((todo) => (
-                  <Todo
-                    key={`todo-list-by-goal-${todo.id}`}
-                    index={todo.id}
-                    todo={todo}
-                    showDropdownOnHover
-                  />
-                ))}
-              </ul>
-            )}
-            {hasNextPage && (
-              <div ref={ref} className="flex justify-center pb-15 pt-20">
-                <LoadingSpinner size={20} />
-              </div>
-            )}
+          <div className="relative">
+            <div
+              className={cn(
+                "pointer-events-none absolute left-0 top-0 h-50 w-full bg-gradient-to-b to-transparent transition-opacity duration-300",
+                showTopGradient ? "opacity-100" : "opacity-0",
+                done ? "from-slate-200" : "from-white",
+              )}
+            />
+            <div
+              className={cn(
+                "scrollbar mt-16 max-h-152 overflow-y-scroll",
+                done && "white",
+              )}
+              ref={scrollRef}
+            >
+              {data.todos.length > 0 && (
+                <ul className="flex flex-col gap-8 pr-5">
+                  {data.todos.map((todo) => (
+                    <Todo
+                      key={`todo-list-by-goal-${todo.id}`}
+                      index={todo.id}
+                      todo={todo}
+                      showDropdownOnHover
+                    />
+                  ))}
+                </ul>
+              )}
+              {hasNextPage && (
+                <div ref={ref} className="flex justify-center pb-15 pt-20" />
+              )}
+            </div>
+            <div
+              className={cn(
+                "pointer-events-none absolute bottom-0 left-0 h-50 w-full bg-gradient-to-t to-transparent transition-opacity duration-300",
+                showBottomGradient ? "opacity-100" : "opacity-0",
+                done ? "from-slate-200" : "from-white",
+              )}
+            />
           </div>
         ) : (
           <div className="absolute inset-0 flex items-center justify-center">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -37,6 +37,10 @@ body {
     @apply rounded-full bg-slate-200;
   }
 
+  .scrollbar.white::-webkit-scrollbar-thumb {
+    @apply rounded-full bg-slate-100;
+  }
+
   /* 수평 스크롤바 유틸리티 */
   .scrollbar-horizontality::-webkit-scrollbar {
     height: 4px;


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->
## 📑 작업 개요
- 목표 상세 페이지 투두리스트 UI 수정

<!-- 이 작업을 진행한 이유 -->
## ✨ 작업 이유
- 다시 보니 목표 상세 페이지 무한스크롤 관련 디자인이 피그마에 존재하더군요🥲 컴포넌트 페이지에 있어서 누락됐었던 것 같고, 디자인과 동일하게 수정하였습니다.

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->
## 📌 작업 내용
- 목표 상세 페이지 투두리스트 컨테이너 높이 고정
- 스크롤 가능한 개수의 투두리스트가 존재할 때 상/하단에 그라디언트 효과 추가

<!-- (선택) 리뷰어에게 전하고 싶은 말 -->
## 🤝🏻 해당 부분을 중점적으로 리뷰해주세요!
- [이전 PR](https://github.com/codeit-si/buildone-client/pull/179)의 실행 화면과 함께 보시면 변경 사항이 한눈에 들어오실 거예요!
- 스크롤 이벤트밖에 방법이 없나 싶은데 혹시 좋은 아이디어 있으신 분은 코멘트 남겨주세요.

<!-- (선택) 실행 화면 캡처 또는 영상 업로드 -->
## 🖥️ 실행 화면

https://github.com/user-attachments/assets/87848d30-628f-4368-8984-36d83db1bc1b


<!-- 관련 이슈 번호 체크 -->
## 🎟️ 관련 이슈

close: #258 
