### PR TITLE
[DEV 162] 회원가입/로그인 페이지 하단 여백 추가

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -8,7 +8,7 @@ export default function Layout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="mx-16 mt-65 flex flex-col items-center md:mt-81 lg:mt-137">
+    <div className="mx-16 mb-40 mt-65 flex flex-col items-center md:mt-81 lg:mt-137">
       <Link href="/">
         <MainLogo aria-label="BuilDone 로고" />
       </Link>


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->
## 📑 작업 개요
- 회원가입/로그인 페이지 하단 여백 추가

<!-- 이 작업을 진행한 이유 -->
## ✨ 작업 이유
- 현재 로그인/회원가입 페이지 모두 하단 여백이 지정되어 있지 않아서 화면 세로 사이즈가 콘텐츠보다 작을 경우 텍스트가 하단에 붙은 것처럼 보였습니다.

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->
## 📌 작업 내용
- 회원가입/로그인 페이지 하단 여백 추가

<!-- (선택) 실행 화면 캡처 또는 영상 업로드 -->
## 🖥️ 실행 화면
[수정 전]

![image](https://github.com/user-attachments/assets/49d8a20b-1895-4b63-9132-7edc5e8209c2)

[수정 후]

![image](https://github.com/user-attachments/assets/d2b45e62-3762-4dbd-86e3-2f8d1222ce5d)

<!-- 관련 이슈 번호 체크 -->
## 🎟️ 관련 이슈
close: #286 
