### PR TITLE
[Dev 169] 로그인 이후 로딩 표시 추가

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -11,7 +11,7 @@ export default function LoginPage() {
   return (
     <div className="mt-57 space-y-40">
       <LoginForm />
-      <AuthSwitch isLoginPage />
+      <AuthSwitch loginPage />
     </div>
   );
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -10,7 +10,7 @@ export default function SignUpPage() {
   return (
     <div className="mt-57 space-y-40">
       <SignUpForm />
-      <AuthSwitch isLoginPage={false} />
+      <AuthSwitch />
     </div>
   );
 }

--- a/src/components/auth/auth-switch.tsx
+++ b/src/components/auth/auth-switch.tsx
@@ -1,18 +1,18 @@
 import Link from "next/link";
 
 interface AuthSwitchProps {
-  isLoginPage: boolean;
+  loginPage?: boolean;
 }
 
-export default function AuthSwitch({ isLoginPage }: AuthSwitchProps) {
+export default function AuthSwitch({ loginPage = false }: AuthSwitchProps) {
   return (
     <p className="flex justify-center gap-x-4 text-sm font-medium">
-      {isLoginPage ? "빌던이 처음이신가요?" : "이미 회원이신가요?"}
+      {loginPage ? "빌던이 처음이신가요?" : "이미 회원이신가요?"}
       <Link
-        href={isLoginPage ? "/signup" : "/login"}
+        href={loginPage ? "/signup" : "/login"}
         className="text-dark-blue-500 underline"
       >
-        {isLoginPage ? "회원가입" : "로그인"}
+        {loginPage ? "회원가입" : "로그인"}
       </Link>
     </p>
   );

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -15,6 +15,7 @@ import { login } from "@/services/auth";
 import { useUserStore } from "@/store/user-store";
 
 import LabeledInput from "../@common/input/labeled-input";
+import LoadingSpinner from "../@common/loading-spinner";
 
 const loginSchema = z.object({
   email: z
@@ -30,6 +31,8 @@ type LoginSchemaKey = keyof LoginSchema;
 export default function LoginForm() {
   const router = useRouter();
   const { setUserInfo } = useUserStore();
+
+  const [isLoading, setIsLoading] = useState(false);
 
   const {
     register,
@@ -57,6 +60,8 @@ export default function LoginForm() {
   }, [debouncedEmail, trigger]);
 
   const onSubmit = async (data: LoginSchema) => {
+    setIsLoading(true);
+
     try {
       const response = await login(data.email, data.password);
 
@@ -64,6 +69,8 @@ export default function LoginForm() {
 
       router.push("/dashboard");
     } catch (error: unknown) {
+      setIsLoading(false);
+
       if (error instanceof ApiError) {
         if (
           error.code === LOGIN_ERROR_CODE.INVALID_EMAIL_FORMAT ||
@@ -115,9 +122,9 @@ export default function LoginForm() {
       <Button
         type="submit"
         className="mt-48 w-full"
-        disabled={!isDirty || !isValid}
+        disabled={!isDirty || !isValid || isLoading}
       >
-        로그인하기
+        {isLoading ? <LoadingSpinner size={20} /> : "로그인하기"}
       </Button>
     </form>
   );


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->
## 📑 작업 개요
- 로그인 이후 대시보드 페이지 로딩 전까지 로딩 스피너 노출

<!-- 이 작업을 진행한 이유 -->
## ✨ 작업 이유
- 대시보드 페이지가 로딩되는 상당한 시간동안(특히 로컬에서) 로그인 페이지에서 머무는 문제가 있었습니다. 대시보드 페이지로 넘어가게끔 하고 로딩 화면이 보이는 것이 가장 좋을 것 같은데, 현재 급하게 수정해야 할 사항들이 많아 임시로 로그인 이후에 로딩 스피너가 보이게끔 수정했습니다.

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->
## 📌 작업 내용
- 로그인 이후 대시보드 페이지 로딩 전까지 로딩 스피너 노출
- 로딩 스피너가 노출되는 동안은 버튼 disabled 상태로 유지

<!-- (선택) 실행 화면 캡처 또는 영상 업로드 -->
## 🖥️ 실행 화면

https://github.com/user-attachments/assets/181b62b6-3dd6-45ad-92ab-980e14a1da2e

<!-- 관련 이슈 번호 체크 -->
## 🎟️ 관련 이슈

close: #304 