### PR TITLE
[Dev 173] 거북목 주의보 알림 관련 버그 수정

### DIFF
--- a/src/lib/fcm-provider.tsx
+++ b/src/lib/fcm-provider.tsx
@@ -2,10 +2,8 @@
 
 import { useEffect } from "react";
 
-import { initializeApp } from "firebase/app";
-import { getMessaging, getToken, onMessage } from "firebase/messaging";
-
 import { useUserStore } from "@/store/user-store";
+import { getFcmToken } from "@/utils/fcm";
 
 export default function FcmProvider() {
   const { setFcmToken } = useUserStore();
@@ -16,43 +14,8 @@ export default function FcmProvider() {
 
       if (permission !== "granted") return;
 
-      const firebaseConfig = {
-        apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-        authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-        projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-        storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-        messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-        appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-        measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
-      };
-
-      const firebaseApp = initializeApp(firebaseConfig);
-
-      const messaging = getMessaging(firebaseApp);
-
-      getToken(messaging, {
-        vapidKey: process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY,
-      })
-        .then((token: string) => {
-          setFcmToken(token);
-        })
-        .catch((err: unknown) => {
-          // eslint-disable-next-line no-console
-          console.log("An error occurred while retrieving token. ", err);
-        });
-
-      onMessage(messaging, (payload) => {
-        const notificationTitle =
-          payload?.notification?.title || "거북목 주의보";
-        const notificationOptions = {
-          body: payload.notification?.body,
-        };
-
-        if (Notification.permission === "granted") {
-          // eslint-disable-next-line no-new
-          new Notification(notificationTitle, notificationOptions);
-        }
-      });
+      const token = await getFcmToken();
+      setFcmToken(token);
     };
 
     onMessageFCM();

--- a/src/services/push-notification/index.ts
+++ b/src/services/push-notification/index.ts
@@ -1,4 +1,5 @@
 import { api } from "@/lib/axios";
+import { PushNotificationSetting } from "@/types/setting";
 
 import { ENDPOINT } from "../endpoint";
 
@@ -22,7 +23,7 @@ export const sendPushNotification = async (
 
 /** 푸시 알림 설정 조회 API */
 export const getPushNotificationSetting = async () => {
-  const { data } = await api.get<{ webPushIsActive: boolean }>(
+  const { data } = await api.get<PushNotificationSetting>(
     ENDPOINT.PUSH.GET_SETTING,
   );
 

--- a/src/types/setting.ts
+++ b/src/types/setting.ts
@@ -1,0 +1,4 @@
+export interface PushNotificationSetting {
+  webPushIsActive: boolean;
+  webPushToken: string | null;
+}

--- a/src/utils/fcm.ts
+++ b/src/utils/fcm.ts
@@ -1,0 +1,39 @@
+import { initializeApp } from "firebase/app";
+import { getMessaging, getToken, onMessage } from "firebase/messaging";
+
+export const getFcmToken = async () => {
+  const firebaseConfig = {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+    measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+  };
+
+  const firebaseApp = initializeApp(firebaseConfig);
+
+  const messaging = getMessaging(firebaseApp);
+
+  const fcmToken = await getToken(messaging, {
+    vapidKey: process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY,
+  });
+
+  onMessage(messaging, (payload) => {
+    const notificationTitle =
+      payload?.notification?.title || "🚨 거북목 주의보! 🚨";
+    const notificationOptions = {
+      body:
+        payload.notification?.body ||
+        "1시간이 지났어요! 자세를 바르게 하고, 목과 어깨를 가볍게 풀어주세요🙂",
+    };
+
+    if (Notification.permission === "granted") {
+      // eslint-disable-next-line no-new
+      new Notification(notificationTitle, notificationOptions);
+    }
+  });
+
+  return fcmToken;
+};


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->
## 📑 작업 개요
- 거북목 주의보 알림 관련 버그 수정

<!-- 이 작업을 진행한 이유 -->
## ✨ 작업 이유
- 기존 로직은 회원가입 이후에 FCM 토큰을 발급받아 서버에 등록했으나, 회원가입 시에 알림을 허용해두지 않은 상태인 사용자가 있을 수 있고, 따라서 FCM 토큰이 제대로 저장되지 않을 수 있었습니다.
-  FCM 토큰 값이 일관적이지 않은 주기로 재발급되기 때문에, 이를 갱신해주지 않을 시 푸시 알림을 제대로 받을 수 없는 문제가 있었습니다.

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->
## 📌 작업 내용
- FCM 토큰 발급 함수 유틸 함수로 추출
- 거북목 주의보 알림 버튼 토글 시 서버에 저장된 FCM 토큰 값과 비교하여 토큰 값 갱신하는 로직 추가

<!-- (선택) 리뷰어에게 전하고 싶은 말 -->
## 🤝🏻 해당 부분을 중점적으로 리뷰해주세요!
궁금한 점있으시면 코멘트 남겨주세요!
+) 현재 알림 주기가 1시간이 아닌 1분으로 설정되어 있습니다. dev 배포 버전에서 확인 후 1시간으로 다시 수정 요청 드릴 예정입니다.

<!-- (선택) 실행 화면 캡처 또는 영상 업로드 -->
## 🖥️ 실행 화면

https://github.com/user-attachments/assets/2c51494f-e7ef-4776-a630-ad10dcb97746


<!-- 관련 이슈 번호 체크 -->
## 🎟️ 관련 이슈

close: #312 
