### PR TITLE
[DEV 174] 프로필 카드 공유 기능 준비중 토스트 메시지 추가

### DIFF
--- a/src/components/profile-card/profile-card-actions.tsx
+++ b/src/components/profile-card/profile-card-actions.tsx
@@ -6,6 +6,7 @@ import { motion } from "motion/react";
 
 import SaveIcon from "@/assets/profile-card/download.svg";
 import ShareIcon from "@/assets/profile-card/share.svg";
+import { errorToast } from "@/utils/custom-toast";
 
 interface ProfileCardActionsProps {
   cardRef: RefObject<HTMLDivElement>;
@@ -22,6 +23,10 @@ export default function ProfileCardActions({
         saveAs(blob, `${userName}'s profile-card.png`);
       });
     }
+  };
+
+  const handleShare = () => {
+    errorToast("in-progress-guide", "🚧 준비 중인 기능입니다.");
   };
 
   return (
@@ -43,6 +48,7 @@ export default function ProfileCardActions({
           type="button"
           className="flex size-52 items-center justify-center rounded-8 bg-white shadow-xl transition-transform hover:-translate-y-3 md:size-72"
           title="🚧 준비 중인 기능입니다."
+          onClick={handleShare}
         >
           <ShareIcon className="flex size-30 items-center justify-center md:size-40" />
         </button>


### PR DESCRIPTION
<!-- 작업의 간단한 요약 -->
## 📑 작업 개요
- 프로필 카드 공유 기능 준비중 토스트 메시지 추가

<!-- 핵심적인 코드 변경 사항에 대한 설명 -->
## 📌 작업 내용
- 프로필 카드 공유 기능 준비중 토스트 메시지 추가

<!-- (선택) 실행 화면 캡처 또는 영상 업로드 -->
## 🖥️ 실행 화면

https://github.com/user-attachments/assets/47e8e910-6122-427a-9372-7a628da74437


<!-- 관련 이슈 번호 체크 -->
## 🎟️ 관련 이슈

close: #315 
